### PR TITLE
Unhighlight the htmlapi-client-python project.

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,18 +170,6 @@ limitations under the License.
                       </p>
                   </li>
                   <li class="github-project">
-                      <a href="https://github.com/Comcast/htmlapi-client-python">
-                          <img class="project-logo" src="./img/html-client-python.png" alt="htmlapi-client-python" />
-                          <h3 class="project-title">htmlapi-client-python</h3>
-                      </a>
-                      <p class="project-description">
-                          Python code for driving an HTML-based hypermedia API.
-                      </p>
-                      <p class="project-description">
-                          This is Python code for driving an HTML-based hypermedia API. The top-level method of interest is enter(), where you can supply a URL and arrive at the "start" state of a client state machine. From there, the client can examine semantic objects as annotated by HTML5 microdata, for example with ontologies like <a href="Schema.org">schema.org</a>.
-                      </p>
-                  </li>
-                  <li class="github-project">
                     <a href="https://github.com/Comcast/rulio">
                         <img class="project-logo" src="./img/Rulio_logo.png" alt="rulio" />
                         <h2 class="project-title">rulio</h2>


### PR DESCRIPTION
This project was demo code that went along with a conference talk
given by Jon Moore and was released for reference by request of
several folks in the audience. However, it is really just a body
of reference code and not an active project. The plan is to
migrate this over to a public repository under @comcast-jonm,
which is a more appropriate location for it.