### PR TITLE
Make both Traffic Control links the same

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,7 @@ limitations under the License.
                 <h2>Infrastructure</h2>
                 <ul>
                   <li class="github-project">
-                    <a href="https://github.com/apache/incubator-trafficcontrol">
+                    <a href="https://trafficcontrol.incubator.apache.org">
                         <img class="project-logo" src="./img/traffic_control.png" alt="traffic control" />
                         <h2 class="project-title">traffic control</h2>
                     </a>


### PR DESCRIPTION
The link in the carousel is to the website but the link in the project section is to the github repo.