### PR TITLE
Add pulsar-client-go project

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,6 +202,7 @@ limitations under the License.
                   <li class="additional-projects">
                       <h4>Additional Backend Projects</h4>
                       <ul>
+                        <li><a href="https://github.com/Comcast/pulsar-client-go" rel="noopener">pulsar-client-go</a></li>
                         <li><a href="https://www.github.com/Comcast/connvitals" rel="noopener">connvitals</a></li>
                         <li><a href="https://www.github.com/Comcast/connvitals-monitor" rel="noopener">connvitals-monitor</a></li>
                         <li><a href="https://www.github.com/Comcast/xml-selector">xml-selector</a></li>
@@ -239,7 +240,7 @@ limitations under the License.
                   <li class="additional-projects">
                       <h4>Additional Big Data Projects</h4>
                       <ul>
-                        <li><a href="https://www.github.com/Comcast/cmb">cmb</a></li>    
+                        <li><a href="https://www.github.com/Comcast/cmb">cmb</a></li>
                         <li><a href="https://www.github.com/Comcast/Superior-Cache-ANalyzer" rel="noopener">SCAN</a></li>
                         <li><a href="https://www.github.com/Comcast/sirius-reference-app">sirius-reference-app</a></li>
                         <li><a href="https://github.com/Comcast/MirrorTool-for-Kafka-Connect">MirrorTool for Kafka Connect</a></li>
@@ -624,6 +625,7 @@ limitations under the License.
           <div class="stat-box" id="stat-newest">
             <h3>Our Newest Projects</h3>
             <ul>
+              <li><a href="https://github.com/Comcast/pulsar-client-go" rel="noopener">tsb</a> <span class="repo-description">A Go client library for Apache Pulsar.</span></li>
               <li><a href="https://github.com/Comcast/tsb" rel="noopener">tsb</a> <span class="repo-description">Transitive Source Builder manages downstream, internal, and custom builds dynamically.</span></li>
               <li><a href="https://github.com/Comcast/ip4s" rel="noopener">ip4s</a> <span class="repo-description">IP addresses and similar network data types for Scala and Scala.js</span></li>
               <li><a href="https://github.com/Comcast/Superior-Cache-ANalyzer" rel="noopener">SCAN</a> <span class="repo-description">A tool for inspecting the contents of Apache Traffic Server caches.</span></li>
@@ -633,7 +635,6 @@ limitations under the License.
               <li><a href="https://github.com/Comcast/hypergard">hypergard</a> <span class="repo-description"> A JavaScript client for HAL APIs with support for forms</span></li>
               <li><a href="https://github.com/Comcast/trickster">Trickster</a> <span class="repo-description"> A dashboard accelerator for Prometheus.</span></li>
               <li><a href="https://github.com/Comcast/blueprint">Blueprint</a> <span class="repo-description"> A compact framework for building Android apps with an MVP architecture.</span></li>
-              <li><a href="https://github.com/Comcast/sheens">Sheens</a> <span class="repo-description"> Sheens is an automation engine that hosts message-processing state machines</span></li>
             </ul>
           </div>
           <div class="stat-box">

--- a/index.html
+++ b/index.html
@@ -625,7 +625,7 @@ limitations under the License.
           <div class="stat-box" id="stat-newest">
             <h3>Our Newest Projects</h3>
             <ul>
-              <li><a href="https://github.com/Comcast/pulsar-client-go" rel="noopener">tsb</a> <span class="repo-description">A Go client library for Apache Pulsar.</span></li>
+              <li><a href="https://github.com/Comcast/pulsar-client-go" rel="noopener">pulsar-client-go</a> <span class="repo-description">A Go client library for Apache Pulsar.</span></li>
               <li><a href="https://github.com/Comcast/tsb" rel="noopener">tsb</a> <span class="repo-description">Transitive Source Builder manages downstream, internal, and custom builds dynamically.</span></li>
               <li><a href="https://github.com/Comcast/ip4s" rel="noopener">ip4s</a> <span class="repo-description">IP addresses and similar network data types for Scala and Scala.js</span></li>
               <li><a href="https://github.com/Comcast/Superior-Cache-ANalyzer" rel="noopener">SCAN</a> <span class="repo-description">A tool for inspecting the contents of Apache Traffic Server caches.</span></li>


### PR DESCRIPTION
Adds the [`pulsar-client-go`](https://github.com/Comcast/pulsar-client-go) project under Backend Projects.