### PR TITLE
Issue 240 | Removed Redirector from main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,6 @@ limitations under the License.
                         <li><a href="https://www.github.com/Comcast/connvitals-monitor" rel="noopener">connvitals-monitor</a></li>
                         <li><a href="https://www.github.com/Comcast/xml-selector">xml-selector</a></li>
                         <li><a href="https://www.github.com/Comcast/http-health-check-microservice">http-health-check-microservice</a></li>
-                        <li><a href="https://www.github.com/Comcast/redirector">redirector</a></li>
                         <li><a href="https://www.github.com/Comcast/go-log">go-log</a></li>
                         <li><a href="https://www.github.com/Comcast/cjson-extras">cjson-extras</a></li>
                         <li><a href="https://www.github.com/Comcast/malcolm">malcolm</a></li>


### PR DESCRIPTION
Redundant Redirector project was removed from section *Additional backend projects* #240 