### PR TITLE
remove javascript.js as blog doesn't need it

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -157,7 +157,6 @@ limitations under the License.
         </div>
       </section>
     </footer>
-    <script src="./js/javascript.js"></script>
     <script>
       var GA_PAGEVIEW_SENT = false;
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){


### PR DESCRIPTION
This PR fixes https://github.com/Comcast/Comcast.github.io/issues/211, `blog.html` doesn't use javascript so it's safe to remove.