### PR TITLE
remove Hacktoberfest slide from homepage carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,16 +67,6 @@ limitations under the License.
             <div class="hero-carousel-container" id="about">
                 <ul id="hero-carousel" class="hero-carousel">
                     <li id="slide1" class="hero-slides">
-                            <img class="carousel-hero-img" src="./img/Hacktoberfest-poster.jpg" alt="Hacktoberfest"/>
-                            <div class="slide-text-container">
-                              <h2 class="carousel-slide-title">Hacktoberfest</h2>
-                              <p  class="carousel-text">
-                                Comcast is participating in Hacktoberfest! Find opportunities to contribute to our open source projects.</p>
-                              <p class="carousel-text"> <a class="carousel-text-link" href="./hacktoberfest">
-                                Click here for more info  &#10095;</a></p>
-                            </div>
-                    </li>
-                    <li id="slide2" class="hero-slides">
                             <img class="carousel-hero-img" src="./img/carousel/kuberhealthy.jpg" alt="kuberhealthy"/>
                             <div class="slide-text-container">
                               <h2 class="carousel-slide-title">Kuberhealthy</h2>
@@ -86,7 +76,7 @@ limitations under the License.
                                 Click here for more info  &#10095;</a></p>
                             </div>
                     </li>
-                    <li id="slide3" class="hero-slides">
+                    <li id="slide2" class="hero-slides">
                             <img class="carousel-hero-img" src="./img/carousel/trickstercarousel.jpg" alt="Trickster"/>
                             <div class="slide-text-container">
                               <h2 class="carousel-slide-title">Trickster</h2>
@@ -107,7 +97,7 @@ limitations under the License.
                             Click here for more info  &#10095;</a></p>
                         </div>
                     </li>
-                    <li id="slide3" class="hero-slides">
+                    <li id="slide4" class="hero-slides">
                         <img class="carousel-hero-img" src="./img/carousel/traffic.jpg" alt="Apache Traffic Control"/>
                         <div class="slide-text-container">
                             <h2 class="carousel-slide-title">Traffic Control</h2>
@@ -123,7 +113,7 @@ limitations under the License.
                             </p>
                         </div>
                     </li>
-                    <li id="slide2" class="hero-slides">
+                    <li id="slide5" class="hero-slides">
                         <img id="carousel-img1" class="carousel-hero-img" src="./img/carousel/innovation.jpg" alt="Comcast Innovation Fund"/>
                         <div class="slide-text-container">
                             <h2 class="carousel-slide-title">Open Source Grants</h2>
@@ -139,7 +129,7 @@ limitations under the License.
                             </p>
                         </div>
                     </li>
-                    <li id="slide3" class="hero-slides">
+                    <li id="slide6" class="hero-slides">
                             <img class="carousel-hero-img" src="./img/carousel/jobs.jpg" alt="Jobs"/>
                             <div class="slide-text-container">
                               <h2 class="carousel-slide-title">Jobs</h2>


### PR DESCRIPTION
Hacktoberfest is over so we no longer need the slide on the homepage carousel.