### PR TITLE
update carousel slide numbering

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,16 +67,6 @@ limitations under the License.
             <div class="hero-carousel-container" id="about">
                 <ul id="hero-carousel" class="hero-carousel">
                     <li id="slide1" class="hero-slides">
-                            <img class="carousel-hero-img" src="./img/Hacktoberfest-poster.jpg" alt="Hacktoberfest"/>
-                            <div class="slide-text-container">
-                              <h2 class="carousel-slide-title">Hacktoberfest</h2>
-                              <p  class="carousel-text">
-                                Comcast is participating in Hacktoberfest! Find opportunities to contribute to our open source projects.</p>
-                              <p class="carousel-text"> <a class="carousel-text-link" href="./hacktoberfest">
-                                Click here for more info  &#10095;</a></p>
-                            </div>
-                    </li>
-                    <li id="slide2" class="hero-slides">
                             <img class="carousel-hero-img" src="./img/carousel/kuberhealthy.jpg" alt="kuberhealthy"/>
                             <div class="slide-text-container">
                               <h2 class="carousel-slide-title">Kuberhealthy</h2>


### PR DESCRIPTION
seems that any id over "slide3" for the slide IDs breaks the carousel formatting. will look into that in the future but for now changed the numbers back to what they were previously.