### PR TITLE
Fix grammar error for WebPA project

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,7 +644,7 @@ limitations under the License.
                         <h2 class="project-title">WebPA</h2>
                     </a>
                     <p class="project-description">
-                        WebPA is a combination of a server and client that provide a simple interface to access the TR-181 objects on an RDK device. WebPA leverages XMiDT for the connection to the RDK device.
+                        WebPA is a combination of a server and client that provides a simple interface to access the TR-181 objects on an RDK device. WebPA leverages XMiDT for the connection to the RDK device.
                     </p>
                     <p class="project-description">
                         Webpa is a very simple micro service and client that provides a REST interface to access the TR-181 data model on an RDK device.


### PR DESCRIPTION
This commit fixes a grammar mistake in the WebPA project where we were
using provide rather than provides.