### PR TITLE
Remove second description from PatternLab blurb

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,9 +296,6 @@ limitations under the License.
                     <p class="project-description">
                             A framework designed around helping you and your team build thoughtful, pattern-driven user interfaces using the atomic design principles.
                     </p>
-                    <p class="project-description">
-                        The webpack wrapper around patternlab-node core, providing tasks to interact with the core library and move supporting frontend assets.
-                    </p>
                   </li>
                   <li class="github-project">
                     <a href="https://github.com/Comcast/Surf-N-Perf">


### PR DESCRIPTION
This commit removes an unnecessary secondary description from the
PatternLab blurb.