### PR TITLE
Remove short description from DMC-CIM

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,9 +347,6 @@ limitations under the License.
                         <h2 class="project-title">dmc-sim</h2>
                     </a>
                     <p class="project-description">
-                        ns-3 bindings to support simulation evaluations of Distributed Monotonic Clocks (DMC).
-                    </p>
-                    <p class="project-description">
                         Distributed monotonic clocks (DMC) whose timestamps can reflect causality but which have a component that stays close to wall clock time. This scheme builds on previous hybrid logical clock proposals by adding important operational hooks and by building in mechanisms to prevent a single runaway system clock from dragging a whole cluster's logical clocks forward into the future.  <a href="https://www.youtube.com/watch?v=YqNGbvFHoKM">More at YouTube.</a>
                     </p>
                   </li>


### PR DESCRIPTION
This commit removes the short description from the DMC-CIM blurb to make
the overall description more clear.